### PR TITLE
Add a Maven project file

### DIFF
--- a/FQL_LIB/pom.xml
+++ b/FQL_LIB/pom.xml
@@ -1,0 +1,118 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.categoricaldata</groupId>
+  <artifactId>fql2</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>fql2</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  
+  <build>
+    <!-- Use non-standard src directory -->
+    <sourceDirectory>src</sourceDirectory>
+
+    <plugins>
+      <!-- Use the Eclipse compiler -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <compilerId>eclipse</compilerId>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-eclipse</artifactId>
+            <version>2.5</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      
+      <!-- Generate the jar manifest -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>fql_lib.FQL</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      
+      <!-- Build a standalone FQL jar containing all libraries when 'package' is executed -->
+      <plugin>
+        <groupId>com.jolira</groupId>
+        <artifactId>onejar-maven-plugin</artifactId>
+        <version>1.4.4</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>one-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+
+  <dependencies>
+    <dependency>
+        <groupId>net.sourceforge.collections</groupId>
+        <artifactId>collections-generic</artifactId>
+        <version>4.01</version>
+    </dependency>
+    <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.json</artifactId>
+        <version>1.0.4</version>
+    </dependency>
+    <dependency>
+        <groupId>jparsec</groupId>
+        <artifactId>jparsec</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+    <dependency>
+        <groupId>net.sf.jung</groupId>
+        <artifactId>jung-algorithms</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+    <dependency>
+        <groupId>net.sf.jung</groupId>
+        <artifactId>jung-api</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+    <dependency>
+        <groupId>net.sf.jung</groupId>
+        <artifactId>jung-graph-impl</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+    <dependency>
+        <groupId>net.sf.jung</groupId>
+        <artifactId>jung-io</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+    <dependency>
+        <groupId>net.sf.jung</groupId>
+        <artifactId>jung-visualization</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+    <dependency>
+        <groupId>com.fifesoft</groupId>
+        <artifactId>rsyntaxtextarea</artifactId>
+        <version>2.5.1</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
I figured I'd go ahead and share this, but I won't be offended if you don't want to support Maven.

This project file allows building FQL2 via Maven, and consumption of the build artifacts via Maven-compatible dependency managers and build tools.

Support for building a standalone fql2 JAR is implemented as part of the 'package' target, via one-jar.

The jars in lib/ are not used by Maven; equivalent dependencies are defined in the pom file. They can be deleted if relying solely on Maven, but doing so seemed too presumptuous on my part.